### PR TITLE
Profile

### DIFF
--- a/src/data/interfaces/IFamily.ts
+++ b/src/data/interfaces/IFamily.ts
@@ -13,5 +13,5 @@ export interface IFamily extends TFamilyDoc, Document {
 
 export type TFamilyFilter = Pick<
   Partial<IFamily>,
-  'appId' | 'owner' | 'planId' | 'isFull' | 'renewal' | 'name'
+  'appId' | 'owner' | 'planId' | 'isFull' | 'tenure' | 'name'
 >;

--- a/src/data/interfaces/ISubscriber.ts
+++ b/src/data/interfaces/ISubscriber.ts
@@ -1,9 +1,18 @@
 import { Document, Types } from 'mongoose';
+import { TJoinMethod } from '@/web/validators/family.validation';
 
-export interface ISubscriber extends Document {
+export type TSubscriber = {
+  userId: string;
+  familyId: string;
+  joinMethod: TJoinMethod;
+};
+
+type TSubscriberDoc = Omit<TSubscriber, 'userId' | 'familyId'>;
+export interface ISubscriber extends TSubscriberDoc, Document {
   userId: Types.ObjectId;
   familyId: Types.ObjectId;
-  joinMethod: string;
   isActive: boolean;
   revokeAccess: boolean;
 }
+
+export type TSubscriberFilter = Partial<Pick<TSubscriber, 'userId' | 'familyId' | 'joinMethod'>>;

--- a/src/data/interfaces/ISubscription.ts
+++ b/src/data/interfaces/ISubscription.ts
@@ -1,24 +1,17 @@
 import { Document, Types } from 'mongoose';
-import { TOnboarding, TRenewal } from '@/web/validators/family.validation';
 
 export type TSubscriptionCreate = {
-  appId: string;
-  planId: string;
-  slotsAvailable: number;
-  renewal: TRenewal;
-  onboarding: TOnboarding;
   userId: string;
+  familyId: string;
+  transactionId?: string;
 };
 
-type TSubscriptionDoc = Omit<TSubscriptionCreate, 'appId' | 'planId' | 'userId'>;
+type TSubscriptionDoc = Omit<TSubscriptionCreate, 'userId' | 'familyId' | 'transactionId'>;
 
 export interface ISubscription extends TSubscriptionDoc, Document {
-  appId: Types.ObjectId;
-  planId: Types.ObjectId;
   userId: Types.ObjectId;
+  familyId: Types.ObjectId;
+  transactionId: Types.ObjectId;
 }
 
-export type TSubscriptionFilter = Pick<
-  Partial<TSubscriptionCreate>,
-  'appId' | 'planId' | 'userId' | 'renewal'
->;
+export type TSubscriptionFilter = Pick<Partial<TSubscriptionCreate>, 'userId' | 'familyId'>;

--- a/src/data/interfaces/IUser.ts
+++ b/src/data/interfaces/IUser.ts
@@ -1,4 +1,5 @@
 import { Document, Types } from 'mongoose';
+import { TUpdateUserBody } from '@/web/validators/user.validation';
 
 export interface IUser extends Document {
   email: string;
@@ -20,6 +21,9 @@ export interface IUser extends Document {
   wallet: Types.ObjectId;
   earnings: number;
 }
+type TUpdateUserDoc = Pick<Partial<IUser>, 'verified'>;
+
+export type TUpdateUser = TUpdateUserBody | TUpdateUserDoc;
 
 export type TUserFilter = Pick<Partial<IUser>, '_id' | 'email' | 'username' | 'phoneNumber'>;
 
@@ -29,5 +33,3 @@ export type TFilterOptions = {
   sensitive: boolean;
   sensitiveFields: TSensitiveFields | [TSensitiveFields];
 };
-
-export type TUpdateUserEntity = Pick<Partial<IUser>, 'firstName' | 'verified' | 'lastName'>;

--- a/src/data/models/family.model.ts
+++ b/src/data/models/family.model.ts
@@ -9,9 +9,18 @@ export const OnboardingSchema = new Schema<TOnboarding>(
       type: String,
       required: true,
     },
-    url: String,
-    email: String,
-    password: String,
+    url: {
+      type: String,
+      select: false,
+    },
+    email: {
+      type: String,
+      select: false,
+    },
+    password: {
+      type: String,
+      select: false,
+    },
   },
   {
     _id: false,
@@ -46,7 +55,7 @@ const FamilySchema = new Schema(
       type: Number,
       required: true,
     },
-    slotsAvailable: {
+    noOfAccounts: {
       type: Number,
       required: true,
     },
@@ -54,7 +63,11 @@ const FamilySchema = new Schema(
       type: Date,
       required: true,
     },
-    renewal: {
+    subscriptionEnd: {
+      type: Date,
+      required: true,
+    },
+    tenure: {
       type: String,
       required: true,
     },
@@ -64,7 +77,7 @@ const FamilySchema = new Schema(
     },
     isFull: {
       type: Boolean,
-      default: false,
+      required: true,
     },
   },
   {

--- a/src/data/models/subscriber.model.ts
+++ b/src/data/models/subscriber.model.ts
@@ -1,7 +1,7 @@
 import { Schema, model } from 'mongoose';
 import { ISubscriber } from '../../data/interfaces/ISubscriber';
 
-const SubscriptionSchema = new Schema(
+const SubscriberSchema = new Schema(
   {
     familyId: {
       type: Schema.Types.ObjectId,
@@ -31,4 +31,4 @@ const SubscriptionSchema = new Schema(
   },
 );
 
-export const Subscription = model<ISubscriber>('Subscription', SubscriptionSchema);
+export const Subscriber = model<ISubscriber>('Subscriber', SubscriberSchema);

--- a/src/data/models/subscription.model.ts
+++ b/src/data/models/subscription.model.ts
@@ -1,35 +1,22 @@
 import { Schema, model } from 'mongoose';
 import { ISubscription } from '../../data/interfaces/ISubscription';
-import { OnboardingSchema } from './family.model';
 
 const SubscriptionSchema = new Schema(
   {
-    appId: {
-      type: Schema.Types.ObjectId,
-      ref: 'Application',
-      required: true,
-    },
-    planId: {
-      type: Schema.Types.ObjectId,
-      ref: 'Plan',
-      required: true,
-    },
-    slotsAvailable: {
-      type: Number,
-      required: true,
-    },
-    renewal: {
-      type: String,
-      required: true,
-    },
-    onboarding: {
-      type: OnboardingSchema,
-      required: true,
-    },
     userId: {
       type: Schema.Types.ObjectId,
       ref: 'User',
       required: true,
+    },
+    familyId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Family',
+      required: true,
+    },
+    transactionId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Transaction',
+      // required: true,
     },
   },
   {

--- a/src/data/models/subscription.model.ts
+++ b/src/data/models/subscription.model.ts
@@ -6,12 +6,12 @@ const SubscriptionSchema = new Schema(
   {
     appId: {
       type: Schema.Types.ObjectId,
-      ref: 'User', // !ref App
+      ref: 'Application',
       required: true,
     },
     planId: {
       type: Schema.Types.ObjectId,
-      ref: 'User', //! ref Plan
+      ref: 'Plan',
       required: true,
     },
     slotsAvailable: {
@@ -25,7 +25,6 @@ const SubscriptionSchema = new Schema(
     onboarding: {
       type: OnboardingSchema,
       required: true,
-      _id: false,
     },
     userId: {
       type: Schema.Types.ObjectId,

--- a/src/data/models/user.model.ts
+++ b/src/data/models/user.model.ts
@@ -58,6 +58,7 @@ const UserSchema = new Schema(
     recoveryCodes: {
       type: [{ hash: String, used: Boolean }],
       select: false,
+      _id: false,
     },
     maxFamilies: {
       type: Number,

--- a/src/data/models/user.model.ts
+++ b/src/data/models/user.model.ts
@@ -35,6 +35,9 @@ const UserSchema = new Schema(
       required: true,
       unique: true,
     },
+    dob: {
+      type: Date,
+    },
     role: {
       type: String,
       enum: UserRole,

--- a/src/data/repositories/family.repository.ts
+++ b/src/data/repositories/family.repository.ts
@@ -7,12 +7,20 @@ import { Family } from '../models/index';
 import BaseRepository from './base.repository';
 
 export class FamilyRepository extends BaseRepository {
-  static async create(familyData: TCreateFamilyBody, ownerId: string, maxSubscribers: number) {
+  static async create(
+    familyData: TCreateFamilyBody,
+    ownerId: string,
+    maxSubscribers: number,
+    isFull: boolean,
+    subscriptionEnd: Date,
+  ) {
     try {
       const family = new Family({
         ...familyData,
         owner: ownerId,
         maxSubscribers,
+        isFull,
+        subscriptionEnd,
       });
       await family.save();
 
@@ -27,11 +35,15 @@ export class FamilyRepository extends BaseRepository {
   }
 
   static async findById(id: string) {
-    return Family.findById(id);
+    return Family.findById(id).populate('appId');
   }
 
   static async findOne(filter: TFindFamiliesQuery) {
     return Family.findOne(filter);
+  }
+
+  static async findOwner(filter: { owner: string }) {
+    return Family.find(filter).populate('appId').populate('planId').exec();
   }
 
   static async update(id: string, newData: TUpdateFamilyBody) {

--- a/src/data/repositories/subscriber.repository.ts
+++ b/src/data/repositories/subscriber.repository.ts
@@ -1,0 +1,34 @@
+import { TSubscriber, TSubscriberFilter } from '../interfaces/ISubscriber';
+import { Subscriber } from '../models/subscriber.model';
+import BaseRepository from './base.repository';
+
+export class SubscriberRepository extends BaseRepository {
+  static async create(entity: TSubscriber) {
+    try {
+      const subscriber = await Subscriber.create(entity);
+      return subscriber;
+    } catch (error) {
+      this.handleRepositoryError(error);
+    }
+  }
+
+  static async findAll(filter: TSubscriberFilter) {
+    const subscribers = await Subscriber.find(filter);
+    return subscribers;
+  }
+
+  static async findOne(filter: TSubscriberFilter) {
+    const subscriber = await Subscriber.findOne(filter);
+    return subscriber;
+  }
+
+  static async update(filter: TSubscriberFilter) {
+    const subscriber = await Subscriber.findOneAndUpdate(filter, {}, { new: true });
+    return subscriber;
+  }
+
+  static async delete(filter: TSubscriberFilter) {
+    const subscriber = await Subscriber.findOneAndDelete(filter);
+    return subscriber;
+  }
+}

--- a/src/data/repositories/subscription.repository.ts
+++ b/src/data/repositories/subscription.repository.ts
@@ -9,7 +9,6 @@ export class SubscriptionRepository extends BaseRepository {
       await subscription.save();
 
       return subscription;
-      return subscription;
     } catch (error) {
       this.handleRepositoryError(error);
     }

--- a/src/data/repositories/user.repository.ts
+++ b/src/data/repositories/user.repository.ts
@@ -1,7 +1,7 @@
 import { User } from '../models';
 import BaseRepository from './base.repository';
 import { TCreateUserBody } from '@/web/validators/user.validation';
-import { TFilterOptions, TUpdateUserEntity, TUserFilter } from '../interfaces/IUser';
+import { TFilterOptions, TUserFilter, TUpdateUser } from '../interfaces/IUser';
 
 export class UserRepository extends BaseRepository {
   static async create(entity: TCreateUserBody) {
@@ -23,7 +23,7 @@ export class UserRepository extends BaseRepository {
     return User.findById(id);
   }
 
-  static async findOne(filter: any) {
+  static async findOne(filter: TUserFilter) {
     return User.findOne(filter);
   }
 
@@ -37,7 +37,7 @@ export class UserRepository extends BaseRepository {
     return await query;
   }
 
-  static async update(id: any, entity: TUpdateUserEntity) {
+  static async update(id: string, entity: TUpdateUser) {
     try {
       return User.findByIdAndUpdate(id, entity, { new: true });
     } catch (error) {

--- a/src/logic/dtos/Family/Family-response.dto.ts
+++ b/src/logic/dtos/Family/Family-response.dto.ts
@@ -7,7 +7,7 @@ export class FamilyResponseDto {
       owner: family.owner,
       name: family.name,
       maxSubscribers: family.maxSubscribers,
-      slotsAvailable: family.slotsAvailable,
+      slotsAvailable: family.noOfAccounts,
       isFull: family.isFull,
     };
   }
@@ -16,17 +16,18 @@ export class FamilyResponseDto {
     return families.map((family) => FamilyResponseDto.from(family));
   }
 
-  static create(family: IFamily, subscriptionId: string, appName: string) {
+  static create(family: IFamily, subscriptionId: string, appName: string, planName: string) {
     return {
       id: family._id,
       name: family.name,
       appName,
+      planName,
       subscriptionId,
       maxUsers: family.maxSubscribers,
-      slotsAvailable: family.slotsAvailable,
-      completed: 'transactionIds[]',
-      pending: 'transactionIds[]',
-      revoked: 'transactionIds[]',
+      slotsAvailable: family.noOfAccounts,
+      completed: null,
+      pending: null,
+      revoked: null,
     };
   }
 }

--- a/src/logic/services/auth.service.ts
+++ b/src/logic/services/auth.service.ts
@@ -22,7 +22,7 @@ export class AuthService {
     if (user.verified) throw new ConflictException({ message: 'You are already verified' });
 
     const [verifiedUser, wallet] = await Promise.all([
-      UserRepository.update({ _id: user._id }, { verified: true }),
+      UserRepository.update(user._id, { verified: true }),
       WalletRepository.create({ userId: user._id }),
     ]);
 

--- a/src/logic/services/family.service.ts
+++ b/src/logic/services/family.service.ts
@@ -8,13 +8,13 @@ import { FamilyResponseDto } from '../../logic/dtos/Family';
 import {
   TCreateFamilyBody,
   TFindFamiliesQuery,
-  TJoinMethod,
   TUpdateFamilyBody,
 } from '@/web/validators/family.validation';
 import { SubscriptionService } from './subscription.service';
 import { ApplicationRepository } from '@/data/repositories/application.repository';
 import { PlanRepository } from '@/data/repositories/plan.repository';
-import { SubscriberRepository } from '@/data/repositories/subscriber.repository';
+import { calcEndDate } from '@/utils/end-date.util';
+import { SubscriptionRepository } from '@/data/repositories';
 
 export class FamilyService {
   static async create(
@@ -26,69 +26,61 @@ export class FamilyService {
 
     const plan = await PlanRepository.findById(familyData.planId);
     if (!plan) throw new NotFoundException('Plan not found');
-    // ! possible transactions {3}
-    const family = await FamilyRepository.create(familyData, ownerId, plan.accountSlots);
+
+    if (familyData.noOfAccounts > plan.accountSlots)
+      throw new ForbiddenException({
+        message: "the number of accounts is larger than the plan's capacity",
+      });
+
+    const isFull = familyData.noOfAccounts === plan.accountSlots;
+    const subscriptionEnd = calcEndDate(familyData.subscriptionStart, familyData.tenure);
+    // ! transaction
+    const family = await FamilyRepository.create(
+      familyData,
+      ownerId,
+      plan.accountSlots,
+      isFull,
+      subscriptionEnd,
+    );
 
     if (!family) {
-      throw new NotFoundException('Failed to create family');
+      throw new ServerException({ message: 'Failed to create family' });
     }
 
     const subscription = await SubscriptionService.create({
-      appId: familyData.appId,
-      planId: familyData.planId,
-      onboarding: familyData.onboarding,
-      slotsAvailable: familyData.slotsAvailable,
-      renewal: familyData.renewal,
       userId: ownerId,
+      familyId: family._id,
     });
 
     return {
       message: 'Family Created',
-      data: FamilyResponseDto.create(family.toObject(), subscription._id, app.appName),
+      data: FamilyResponseDto.create(family.toObject(), subscription._id, app.appName, plan.name),
     };
   }
 
-  static async createSubscriber(familyId: string, userId: string, joinMethod: string) {
+  static async joinFamily(familyId: string, userId: string) {
     const family = await FamilyRepository.findById(familyId);
     if (!family) throw new NotFoundException('No family found');
     else if (family.isFull) throw new ForbiddenException({ message: 'this family is full' });
     else if (family.owner.equals(userId))
       throw new ForbiddenException({ message: 'family owner cannot be a subscriber' });
 
-    if (await SubscriberRepository.findOne({ familyId, userId }))
+    if (await SubscriptionRepository.findOne({ familyId, userId }))
       throw new ForbiddenException({ message: 'you already belong to this family' });
 
-    const subscriber = await SubscriberRepository.create({
-      familyId,
-      userId,
-      joinMethod: joinMethod as TJoinMethod,
-    });
-    if (!subscriber)
-      throw new ServerException({
-        'failed to create a subscriber': `familyId: ${familyId}, userId: ${userId}`,
-        message: 'failed to create a subscriber',
-      });
+    // ! transaction
+    const subscription = await SubscriptionService.create({ userId, familyId });
 
-    const slots = --family.slotsAvailable;
-    const maxed = slots === 0;
-    family.slotsAvailable = slots;
+    const accounts = ++family.noOfAccounts;
+    const maxed = accounts === family.maxSubscribers;
+    family.noOfAccounts = accounts;
     family.isFull = maxed;
 
-    const updatedFamily = await (
-      await family.save()
-    ).populate({
-      path: 'appId',
-      select: 'appName',
-    });
-
-    const user = await subscriber.populate({
-      path: 'userId',
-      select: 'username',
-    });
+    await family.save();
 
     return {
-      message: 'subscriber added to family',
-      data: { subscriber: user, family: updatedFamily },
+      message: 'user added to family',
+      data: subscription,
     };
   }
 
@@ -115,21 +107,22 @@ export class FamilyService {
 
     return {
       message: 'Family fetched',
-      data: FamilyResponseDto.from(family.toObject()),
+      data: family,
     };
   }
 
   static async getFamilyOwner(
-    reqUser: string,
+    userId: string,
   ): Promise<{ message: string; data: FamilyResponseDto[] }> {
-    const family = await FamilyRepository.find({ owner: reqUser });
-    if (!family) {
+    const families = await FamilyRepository.findOwner({ owner: userId });
+
+    if (!families) {
       throw new NotFoundException('No family found');
     }
 
     return {
       message: 'Family fetched',
-      data: FamilyResponseDto.fromMany(family),
+      data: families,
     };
   }
 
@@ -173,8 +166,6 @@ export class FamilyService {
     };
   }
 
-  static async updateSubscriber() {}
-
   static async delete(
     familyId: string,
     reqUser: string,
@@ -192,6 +183,4 @@ export class FamilyService {
       message: 'Family deleted',
     };
   }
-
-  static async deleteSubscriber() {}
 }

--- a/src/logic/services/subscription.service.ts
+++ b/src/logic/services/subscription.service.ts
@@ -5,25 +5,24 @@ import { NotFoundException, ServerException } from '@/utils/exceptions';
 export class SubscriptionService {
   static async create(entity: TSubscriptionCreate) {
     const subscription = await SubscriptionRepository.create(entity);
-    if (!subscription)
-      throw new ServerException({ message: `failed to create subscription for ${entity.userId}` });
+    if (!subscription) throw new ServerException({ message: 'failed to create subscription' });
 
     return subscription;
   }
 
-  static async getAll(filter: TSubscriptionFilter) {
+  static async findAll(filter: TSubscriptionFilter) {
     const subscriptions = await SubscriptionRepository.find(filter);
     return subscriptions;
   }
 
-  static async getById(subscriptionId: string) {
+  static async findById(subscriptionId: string) {
     const subscription = await SubscriptionRepository.findById(subscriptionId);
     if (!subscription) throw new NotFoundException('subscription not found');
 
     return subscription;
   }
 
-  static async getOne(filter: TSubscriptionFilter) {
+  static async findOne(filter: TSubscriptionFilter) {
     const subscription = await SubscriptionRepository.findOne(filter);
     if (!subscription) throw new NotFoundException('subscription not found');
 

--- a/src/logic/services/user.service.ts
+++ b/src/logic/services/user.service.ts
@@ -1,7 +1,7 @@
 import { NotFoundException } from '../../utils/exceptions/index';
 import { UserRepository } from '../../data/repositories/user.repository';
 import { UserResponseDto } from '../../logic/dtos/User';
-import { TCreateUserBody } from '@/web/validators/user.validation';
+import { TCreateUserBody, TUpdateUserBody } from '@/web/validators/user.validation';
 import { Encryption } from '@/utils/encryption.utils';
 import { TUserFilter, TFilterOptions } from '@/data/interfaces/IUser';
 
@@ -52,13 +52,8 @@ export class UserService {
 
   static async update(
     userId: string,
-    updateUserDto: any,
+    updateUserDto: TUpdateUserBody,
   ): Promise<{ message: string; data: UserResponseDto }> {
-    const user = await UserRepository.findById(userId);
-    if (!user) {
-      throw new NotFoundException('No user found');
-    }
-
     const updatedUser = await UserRepository.update(userId, updateUserDto);
 
     if (!updatedUser) {
@@ -71,8 +66,8 @@ export class UserService {
     };
   }
 
-  static async delete(UserId: string): Promise<{ message: string; data?: UserResponseDto }> {
-    const user = await UserRepository.delete(UserId);
+  static async delete(userId: string): Promise<{ message: string; data?: UserResponseDto }> {
+    const user = await UserRepository.delete(userId);
     if (!user) {
       throw new NotFoundException('No user found');
     }

--- a/src/utils/end-date.util.ts
+++ b/src/utils/end-date.util.ts
@@ -1,0 +1,29 @@
+/* eslint-disable indent */
+import { TTenure } from '@/web/validators/family.validation';
+
+export function calcEndDate(startDate: Date, tenure: TTenure) {
+  const endDate = new Date(startDate);
+  switch (tenure) {
+    case 'daily':
+      endDate.setDate(endDate.getDate() + 1);
+      break;
+    case 'weekly':
+      endDate.setDate(endDate.getDate() + 7);
+      break;
+    case 'monthly':
+      endDate.setMonth(endDate.getMonth() + 1);
+      break;
+    case 'quarterly':
+      endDate.setMonth(endDate.getMonth() + 3);
+      break;
+    case 'biannually':
+      endDate.setMonth(endDate.getMonth() + 6);
+      break;
+    case 'annually':
+      endDate.setFullYear(endDate.getFullYear() + 1);
+      break;
+    default:
+      throw new Error(`Invalid tenure: ${tenure}`);
+  }
+  return endDate;
+}

--- a/src/utils/helpers/plan.helper.ts
+++ b/src/utils/helpers/plan.helper.ts
@@ -2,6 +2,6 @@
  * @enum {string}
  * @readonly
  */
-export const PlanOnBoardingTypes = ['link', 'credential'] as const;
+export const PlanOnBoardingTypes = ['link', 'credential', 'email'] as const;
 
 export type PlanOnBoardingType = (typeof PlanOnBoardingTypes)[number];

--- a/src/web/controllers/family.controller.ts
+++ b/src/web/controllers/family.controller.ts
@@ -19,6 +19,18 @@ export class FamilyController {
     res.status(HttpStatus.OK).json(result);
   }
 
+  static async createSubscriber(req: Request, res: Response) {
+    const joinMethod = req.query.joinMethod;
+    const { message, data } = await FamilyService.createSubscriber(
+      req.params.id,
+      req.user?._id,
+      joinMethod as string,
+    );
+    const result = BaseHttpResponse.success(message, data);
+
+    res.status(HttpStatus.OK).json(result);
+  }
+
   static async getById(req: Request, res: Response) {
     const familyId = req.params.id;
 
@@ -36,6 +48,10 @@ export class FamilyController {
     res.status(HttpStatus.OK).json(result);
   }
 
+  static async getSubscriptions() {}
+
+  static async getSubscribers() {}
+
   static async update(req: Request, res: Response) {
     const familyId = req.params.id;
     const reqUser = req.user?._id;
@@ -46,6 +62,8 @@ export class FamilyController {
     res.status(HttpStatus.OK).json(result);
   }
 
+  static async updateSubscriber() {}
+
   static async delete(req: Request, res: Response) {
     const familyId = req.params.id;
     const reqUser = req.user?._id;
@@ -55,4 +73,6 @@ export class FamilyController {
 
     res.status(HttpStatus.OK).json(result);
   }
+
+  static async deleteSubscriber() {}
 }

--- a/src/web/controllers/family.controller.ts
+++ b/src/web/controllers/family.controller.ts
@@ -19,13 +19,8 @@ export class FamilyController {
     res.status(HttpStatus.OK).json(result);
   }
 
-  static async createSubscriber(req: Request, res: Response) {
-    const joinMethod = req.query.joinMethod;
-    const { message, data } = await FamilyService.createSubscriber(
-      req.params.id,
-      req.user?._id,
-      joinMethod as string,
-    );
+  static async joinFamily(req: Request, res: Response) {
+    const { message, data } = await FamilyService.joinFamily(req.params.id, req.user?._id);
     const result = BaseHttpResponse.success(message, data);
 
     res.status(HttpStatus.OK).json(result);
@@ -50,8 +45,6 @@ export class FamilyController {
 
   static async getSubscriptions() {}
 
-  static async getSubscribers() {}
-
   static async update(req: Request, res: Response) {
     const familyId = req.params.id;
     const reqUser = req.user?._id;
@@ -62,8 +55,6 @@ export class FamilyController {
     res.status(HttpStatus.OK).json(result);
   }
 
-  static async updateSubscriber() {}
-
   static async delete(req: Request, res: Response) {
     const familyId = req.params.id;
     const reqUser = req.user?._id;
@@ -73,6 +64,4 @@ export class FamilyController {
 
     res.status(HttpStatus.OK).json(result);
   }
-
-  static async deleteSubscriber() {}
 }

--- a/src/web/routes/family.routes.ts
+++ b/src/web/routes/family.routes.ts
@@ -6,6 +6,7 @@ import {
   findFamilies,
   updateFamily,
   deleteFamily,
+  joinFamily,
 } from '../../web/validators/family.validation';
 
 export const familyRouter = Router();
@@ -20,20 +21,15 @@ familyRouter.get('/subscriptions', authenticated, FamilyController.getSubscripti
 
 familyRouter.get('/:id', FamilyController.getById);
 
-familyRouter.get(`/:id/${subscribers}`, FamilyController.getSubscribers);
-
 familyRouter.post('/', validateRequest(createFamily), authenticated, FamilyController.create);
 
-familyRouter.post(`/:id/${subscribers}`, authenticated, FamilyController.createSubscriber);
+familyRouter.post(
+  `/:id/${subscribers}`,
+  validateRequest(joinFamily),
+  authenticated,
+  FamilyController.joinFamily,
+);
 
 familyRouter.patch('/:id', validateRequest(updateFamily), authenticated, FamilyController.update);
 
-familyRouter.patch(`/:id/${subscribers}/:userId`, authenticated, FamilyController.updateSubscriber);
-
 familyRouter.delete('/:id', validateRequest(deleteFamily), authenticated, FamilyController.delete);
-
-familyRouter.delete(
-  `/:id/${subscribers}/:userId`,
-  authenticated,
-  FamilyController.deleteSubscriber,
-);

--- a/src/web/routes/family.routes.ts
+++ b/src/web/routes/family.routes.ts
@@ -10,14 +10,30 @@ import {
 
 export const familyRouter = Router();
 
+const subscribers = 'subscribers';
+
 familyRouter.get('/', validateRequest(findFamilies), FamilyController.getAll);
 
 familyRouter.get('/owner', authenticated, FamilyController.getOwner);
 
+familyRouter.get('/subscriptions', authenticated, FamilyController.getSubscriptions);
+
 familyRouter.get('/:id', FamilyController.getById);
+
+familyRouter.get(`/:id/${subscribers}`, FamilyController.getSubscribers);
 
 familyRouter.post('/', validateRequest(createFamily), authenticated, FamilyController.create);
 
+familyRouter.post(`/:id/${subscribers}`, authenticated, FamilyController.createSubscriber);
+
 familyRouter.patch('/:id', validateRequest(updateFamily), authenticated, FamilyController.update);
 
+familyRouter.patch(`/:id/${subscribers}/:userId`, authenticated, FamilyController.updateSubscriber);
+
 familyRouter.delete('/:id', validateRequest(deleteFamily), authenticated, FamilyController.delete);
+
+familyRouter.delete(
+  `/:id/${subscribers}/:userId`,
+  authenticated,
+  FamilyController.deleteSubscriber,
+);

--- a/src/web/routes/user.routes.ts
+++ b/src/web/routes/user.routes.ts
@@ -11,6 +11,6 @@ userRouter.get('/', authenticated, UserController.getAll);
 
 userRouter.get('/:id', authenticated, UserController.getById);
 
-userRouter.patch('/:id', authenticated, validateRequest(updateUser), UserController.update);
+userRouter.patch('/', authenticated, validateRequest(updateUser), UserController.update);
 
-userRouter.delete('/:id', authenticated, UserController.delete);
+userRouter.delete('/', authenticated, UserController.delete);

--- a/src/web/validators/family.validation.ts
+++ b/src/web/validators/family.validation.ts
@@ -7,6 +7,7 @@ import {
   emailSchema,
 } from './lib/common-schema-validation';
 import { Encryption } from '@/utils/encryption.utils';
+import { PlanOnBoardingTypes } from '@/utils/helpers/plan.helper';
 
 // family/:id
 const id = objectIdSchema;
@@ -14,31 +15,31 @@ const id = objectIdSchema;
 const userId = objectIdSchema;
 
 const onboarding = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('link'), url: z.string().url() }),
+  z.object({ type: z.literal(PlanOnBoardingTypes[0]), url: z.string().url() }),
   z.object({
-    type: z.literal('credentials'),
+    type: z.literal(PlanOnBoardingTypes[1]),
     email: emailSchema,
     password: z
       .string()
       .min(1)
       .transform(async (value) => await Encryption.encryptText(value, 10)),
   }),
-  z.object({ type: z.literal('email') }),
+  z.object({ type: z.literal(PlanOnBoardingTypes[2]) }),
 ]);
 
 export type TOnboarding = z.infer<typeof onboarding>;
 
-const renewal = z.union([z.literal('monthly'), z.literal('quarterly'), z.literal('yearly')]);
+const tenure = z.enum(['daily', 'weekly', 'monthly', 'quarterly', 'biannually', 'annually']);
 
-export type TRenewal = z.infer<typeof renewal>;
+export type TTenure = z.infer<typeof tenure>;
 
 const createFamilyBody = z.object({
   name: nameSchema,
   appId: objectIdSchema,
   planId: objectIdSchema,
-  slotsAvailable: z.number(),
-  subscriptionStart: z.coerce.date(), // test when undefined
-  renewal,
+  noOfAccounts: z.number().positive(),
+  subscriptionStart: z.coerce.date(),
+  tenure,
   onboarding,
 });
 
@@ -56,7 +57,7 @@ const findFamiliesQuery = z.object({
   planId: objectIdSchema.optional(),
   owner: objectIdSchema.optional(),
   isFull: z.coerce.boolean().optional(),
-  renewal: renewal.optional(),
+  tenure: tenure.optional(),
 });
 
 export const findFamilies = incomingRequestSchema(
@@ -102,18 +103,14 @@ const joinMethod = z.union([z.literal('join'), z.literal('invite')]);
 
 export type TJoinMethod = z.infer<typeof joinMethod>;
 
-const createFamilySubscribersParam = z.object({
+const joinFamilyParam = z.object({
   id,
 });
 
-const createFamilySubscribersQuery = z.object({
-  joinMethod,
-});
-
-export const createFamilySubscriber = incomingRequestSchema(
+export const joinFamily = incomingRequestSchema(
   emptyObjectSchema,
-  createFamilySubscribersParam,
-  createFamilySubscribersQuery,
+  joinFamilyParam,
+  emptyObjectSchema,
 );
 
 const updateFamilySubscribersParam = z.object({

--- a/src/web/validators/family.validation.ts
+++ b/src/web/validators/family.validation.ts
@@ -8,6 +8,11 @@ import {
 } from './lib/common-schema-validation';
 import { Encryption } from '@/utils/encryption.utils';
 
+// family/:id
+const id = objectIdSchema;
+// ...subscriber/::userId
+const userId = objectIdSchema;
+
 const onboarding = z.discriminatedUnion('type', [
   z.object({ type: z.literal('link'), url: z.string().url() }),
   z.object({
@@ -68,7 +73,7 @@ const updateFamilyBody = z.object({
 });
 
 const updateFamilyParams = z.object({
-  id: objectIdSchema,
+  id,
 });
 
 export const updateFamily = incomingRequestSchema(
@@ -82,7 +87,7 @@ export type TUpdateFamilyBody = z.infer<typeof updateFamilyBody>;
 export type TUpdateFamilyParams = z.infer<typeof updateFamilyParams>;
 
 const deleteFamilyParams = z.object({
-  id: objectIdSchema,
+  id,
 });
 
 export const deleteFamily = incomingRequestSchema(
@@ -92,3 +97,36 @@ export const deleteFamily = incomingRequestSchema(
 );
 
 export type TDeleteFamilyParams = z.infer<typeof deleteFamilyParams>;
+
+const joinMethod = z.union([z.literal('join'), z.literal('invite')]);
+
+export type TJoinMethod = z.infer<typeof joinMethod>;
+
+const createFamilySubscribersParam = z.object({
+  id,
+});
+
+const createFamilySubscribersQuery = z.object({
+  joinMethod,
+});
+
+export const createFamilySubscriber = incomingRequestSchema(
+  emptyObjectSchema,
+  createFamilySubscribersParam,
+  createFamilySubscribersQuery,
+);
+
+const updateFamilySubscribersParam = z.object({
+  id,
+  userId,
+});
+
+const updateFamilySubscribersQuery = z.object({
+  revokeAccess: z.coerce.boolean(), //TODO note: Boolean("false" | "true" | 1) -> true; Boolean(0) -> false
+});
+
+export const updateFamilySubscriber = incomingRequestSchema(
+  emptyObjectSchema,
+  updateFamilySubscribersParam,
+  updateFamilySubscribersQuery,
+);

--- a/src/web/validators/lib/common-schema-validation.ts
+++ b/src/web/validators/lib/common-schema-validation.ts
@@ -54,6 +54,11 @@ export const phoneNumberSchema = z
   .trim()
   .regex(/^(\+?234|0)(70|[89][01])\d{8}$/);
 
+export const accountNumberSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{10}$/);
+
 export const usernameSchema = z
   .string()
   .trim()


### PR DESCRIPTION
- update family operations: create, join, get family by owner and by id
- update family model
- calculate end date of a subscription depending on it's start date
- prevent selection of sensitive onboarding fields on a find* query, except for `type` field
- increment number of family accounts rather than decrement
- update subscription model
- suspend creation of subscriber upon joining a family, create a subscription instead